### PR TITLE
Unneeded enums cause conflicts in global scope.

### DIFF
--- a/CommonModelMessages.proto
+++ b/CommonModelMessages.proto
@@ -40,19 +40,3 @@ message ProtoDoubleRange {
     optional double from = 1;
     optional double to = 2;
 }
-
-enum ProtoTradeSide {
-    BUY = 1;
-    SELL = 2;
-}
-
-enum ProtoQuoteType {
-    BID = 1;
-    ASK = 2;
-}
-
-enum ProtoTimeInForce {
-    GOOD_TILL_DATE = 1;
-    GOOD_TILL_CANCEL = 2;
-    IMMEDIATE_OR_CANCEL = 3;
-}


### PR DESCRIPTION
I tried it in Python, one of errors is shown below:
Invalid descriptor for file "OpenApiModelMessages.proto"
BUY: "BUY" is already defined in "CommonModelMessages.proto".
BUY: Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type,
not children of it. 
Therefore, "BUY" must be unique within the global scope, not just within "ProtoOATradeSide".